### PR TITLE
Make tasks cacheable

### DIFF
--- a/testProjectBase/build_base.gradle
+++ b/testProjectBase/build_base.gradle
@@ -59,7 +59,7 @@ protobuf {
       task.generateDescriptorSet = true
     }
   }
-  enableCacheExperimental = true
+  enableCacheableTasksExperimental = true
 }
 
 // To include all sourceSets in the project jar


### PR DESCRIPTION
Changes to make the cache work - seems to work with Gradle 4.3 not sure about Gradle 4.0

I am using Gradle 4.7 so I am not that interested in older versions. I don't see why people would use Gradle 4.0 over 4.3 (or for the matter 4.7). Maybe the caching can be a "supported" feature only after Gradle 4.3